### PR TITLE
Fix rules and sent frames

### DIFF
--- a/controllers/supervisor/supervisor.py
+++ b/controllers/supervisor/supervisor.py
@@ -242,8 +242,8 @@ class GameSupervisor (Supervisor):
                 if role != constants.COMMENTATOR:
                     sys.stderr.write("Error, only commentator can commentate.\n")
                     return
-                start = command.find('",') + 2
-                comment = '[{:.2f}] {}'.format(self.time / 1000., command[start:-1])
+                start = command.find('",') + 4
+                comment = '[{:.2f}] {}'.format(self.time / 1000., command[start:-2])
                 self.comments_.append(comment)
             elif command.startswith('report('):
                 if role != constants.REPORTER:

--- a/examples_new/commentator_skeleton_py/commentator_skeleton.py
+++ b/examples_new/commentator_skeleton_py/commentator_skeleton.py
@@ -7,7 +7,6 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../common')
 try:
-    print(sys.path)
     from participant import Participant, Game, Frame
 except ImportError as err:
     print('commentator_skeleton: \'participant\' module cannot be imported:', err)
@@ -51,17 +50,17 @@ class Commentator(Participant):
         self.end_of_frame = False
         # TODO self.image = ReceivedImage(self.resolution, self.colorChannels)
 
-        print("I am the commentator for this game!")
+        self.printConsole("I am the commentator for this game!")
 
     def commentate(self, commentary):
         self.send_comment([commentary])
 
     def update(self, received_frame):
-        # print(received_frame.time)
-        # print(received_frame.score)
-        # print(received_frame.reset_reason)
-        # print(received_frame.half_passed)
-        # print(self.end_of_frame)
+        # self.printConsole(received_frame.time)
+        # self.printConsole(received_frame.score)
+        # self.printConsole(received_frame.reset_reason)
+        # self.printConsole(received_frame.half_passed)
+        # self.printConsole(self.end_of_frame)
 
         if (received_frame.reset_reason == Game.GAME_START):
             if not received_frame.half_passed:

--- a/examples_new/common/participant.py
+++ b/examples_new/common/participant.py
@@ -111,6 +111,10 @@ class Participant():
     def send_report(self, report):
         self.send('report', report)
 
+    def printConsole(self, message):
+        print(message)
+        sys.__stdout__.flush()
+
     def check_frame(self, frame):  # you should override this method
         if frame.reset_reason == Game.GAME_END:
             return False

--- a/examples_new/player_random-walk_py/player_random-walk.py
+++ b/examples_new/player_random-walk_py/player_random-walk.py
@@ -8,7 +8,6 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../common')
 try:
-    print(sys.path)
     from participant import Participant
 except ImportError as err:
     print('player_random-walk: \'participant\' module cannot be imported:', err)

--- a/examples_new/player_rulebased-B_py/player_rulebased-B.py
+++ b/examples_new/player_rulebased-B_py/player_rulebased-B.py
@@ -12,7 +12,6 @@ import helper
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../common')
 try:
-    print(sys.path)
     from participant import Participant, Game, Frame
 except ImportError as err:
     print('player_rulebased-B: \'participant\' module cannot be imported:', err)

--- a/examples_new/player_skeleton_py/player_skeleton.py
+++ b/examples_new/player_skeleton_py/player_skeleton.py
@@ -7,7 +7,6 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../common')
 try:
-    print(sys.path)
     from participant import Participant
 except ImportError as err:
     print('player_skeleton: \'participant\' module cannot be imported:', err)

--- a/examples_new/reporter_skeleton_py/reporter_skeleton.py
+++ b/examples_new/reporter_skeleton_py/reporter_skeleton.py
@@ -7,7 +7,6 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/../common')
 try:
-    print(sys.path)
     from participant import Participant
 except ImportError as err:
     print('reporter_skeleton: \'participant\' module cannot be imported:', err)
@@ -53,7 +52,7 @@ class Reporter(Participant):
         # self.image = ReceivedImage(self.resolution, self.colorChannels)
 
         self.paragraphs = []
-        print("I am the reporter for this game!")
+        self.printConsole("I am the reporter for this game!")
 
     def update(self, frame):
         # self.printConsole(frame.time)


### PR DESCRIPTION
Fix [issues](https://github.com/aiwc/test_world/issues/58) 7 and 10:
* [x] fix how the rules are applied
  * 7.1 Sometimes all robots are sent out to the foul area at the same time (I observed this when I manually moved the ball to a goalpost. After the game reset, all robots were sent to the foul zone). -> I could not reproduce it
  * [x] 7.4 When the ball is send out to the corners, the game is restarted in the wrong corner -> ball_y coordinate sign was not switched as in original C++ supervisor controller
  * [x]  7.5 Deadlock does not happen even if the ball stayed still for more than DEADLOCK_DURATION_MS
* [x] fix reset_reason sent multiple times in published frames
* [x] fix print in Python participant programs not printed immediately
* [x] remove quotes from commentator text displayed in labels